### PR TITLE
Use Pattern to speed up matching

### DIFF
--- a/commonmark-ext-replacement/src/main/java/org/commonmark/ext/replacement/ReplacementExtension.java
+++ b/commonmark-ext-replacement/src/main/java/org/commonmark/ext/replacement/ReplacementExtension.java
@@ -5,6 +5,8 @@ import org.commonmark.ext.replacement.internal.ReplacementPostProcessor;
 import org.commonmark.parser.Parser;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Extension for replacement chars using provided map.
@@ -15,17 +17,36 @@ import java.util.Map;
  */
 public class ReplacementExtension implements Parser.ParserExtension {
     private final Map<String, String> mReplacementMap;
+    private final Pattern mKeysPattern;
 
-    private ReplacementExtension(Map<String, String> replacementMap) {
+    private ReplacementExtension(Map<String, String> replacementMap, Pattern keysPattern) {
         mReplacementMap = replacementMap;
+        mKeysPattern = keysPattern;
     }
 
     public static Extension create(Map<String, String> replacementMap) {
-        return new ReplacementExtension(replacementMap);
+        return new ReplacementExtension(replacementMap, getKeysPattern(replacementMap.keySet()));
     }
 
     @Override
     public void extend(Parser.Builder parserBuilder) {
-        parserBuilder.postProcessor(new ReplacementPostProcessor(mReplacementMap));
+        parserBuilder.postProcessor(new ReplacementPostProcessor(mReplacementMap, mKeysPattern));
+    }
+
+    private static Pattern getKeysPattern(Set<String> keys) {
+        StringBuilder sb = new StringBuilder();
+
+        for (String key : keys) {
+            if (sb.length() == 0) {
+                sb.append("(?<=(^|\\s))(");
+            } else {
+                sb.append('|');
+            }
+            sb.append(Pattern.quote(key));
+        }
+
+        sb.append(")(?=($|\\s))");
+
+        return Pattern.compile(sb.toString());
     }
 }

--- a/commonmark-ext-replacement/src/main/java/org/commonmark/ext/replacement/ReplacementExtension.java
+++ b/commonmark-ext-replacement/src/main/java/org/commonmark/ext/replacement/ReplacementExtension.java
@@ -4,6 +4,7 @@ import org.commonmark.Extension;
 import org.commonmark.ext.replacement.internal.ReplacementPostProcessor;
 import org.commonmark.parser.Parser;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -30,23 +31,27 @@ public class ReplacementExtension implements Parser.ParserExtension {
 
     @Override
     public void extend(Parser.Builder parserBuilder) {
-        parserBuilder.postProcessor(new ReplacementPostProcessor(mReplacementMap, mKeysPattern));
+        if (mKeysPattern != null) {
+            parserBuilder.postProcessor(new ReplacementPostProcessor(mReplacementMap, mKeysPattern));
+        }
     }
 
     private static Pattern getKeysPattern(Set<String> keys) {
-        StringBuilder sb = new StringBuilder();
-
-        for (String key : keys) {
-            if (sb.length() == 0) {
-                sb.append("(?<=(^|\\s))(");
-            } else {
-                sb.append('|');
+        if (keys.size() > 0) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("(?<=(^|\\s))(");
+            Iterator<String> iterator = keys.iterator();
+            while (iterator.hasNext()) {
+                sb.append(Pattern.quote(iterator.next()));
+                if (iterator.hasNext()) {
+                    sb.append('|');
+                }
             }
-            sb.append(Pattern.quote(key));
+            sb.append(")(?=($|\\s))");
+
+            return Pattern.compile(sb.toString());
+        } else {
+            return null;
         }
-
-        sb.append(")(?=($|\\s))");
-
-        return Pattern.compile(sb.toString());
     }
 }


### PR DESCRIPTION
This PR brings back `Pattern` and ensures it's created only once for every `ReplacementExtension` object.

For some use cases `Pattern`  is much faster than our current algorithm. 